### PR TITLE
[FIX] utc에서 kst로 변환하여 response반환

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,8 +15,8 @@ model quote {
 model review {
   worry_id   Int      @id
   content    String   @db.VarChar(50)
-  created_at DateTime @db.Timestamp(6)
-  updated_at DateTime @db.Timestamp(6)
+  created_at DateTime @db.Timestamptz(6)
+  updated_at DateTime @db.Timestamptz(6)
   worry      worry    @relation(fields: [worry_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "review_worry_id_fk")
 }
 
@@ -37,22 +37,22 @@ model user {
   name          String   @db.VarChar(50)
   email         String   @db.VarChar(50)
   used_template Int[]
-  created_at    DateTime @db.Timestamp(6)
-  updated_at    DateTime @db.Timestamp(6)
+  created_at    DateTime @db.Timestamptz(6)
+  updated_at    DateTime @db.Timestamptz(6)
   worry         worry[]
 }
 
 model worry {
-  id           Int      @id @default(autoincrement())
+  id           Int       @id @default(autoincrement())
   template_id  Int
   user_id      Int
-  title        String   @db.VarChar(50)
-  answers      String[] @db.VarChar(100)
-  created_at   DateTime @db.Timestamptz(6)
-  updated_at   DateTime @db.Timestamptz(6)
-  deadline     DateTime @db.Date
-  final_answer String?  @db.VarChar(50)
+  title        String    @db.VarChar(50)
+  answers      String[]  @db.VarChar(100)
+  created_at   DateTime  @db.Timestamptz(6)
+  updated_at   DateTime  @db.Timestamptz(6)
+  deadline     DateTime? @db.Date
+  final_answer String?   @db.VarChar(50)
   review       review?
-  template     template @relation(fields: [template_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "worry_template_id_fk")
-  user         user     @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "worry_user_id_fk")
+  template     template  @relation(fields: [template_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "worry_template_id_fk")
+  user         user      @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "worry_user_id_fk")
 }

--- a/src/controller/worryController.ts
+++ b/src/controller/worryController.ts
@@ -13,7 +13,7 @@ const postWorry = async (req: Request, res: Response, next: NextFunction) => {
         const { userId } = req.body;
         const worryCreateDTO: worryCreateDTO = req.body;
         worryCreateDTO.userId = userId;
-        console.log(worryCreateDTO);
+        // console.log(worryCreateDTO);
 
         const data = await worryService.postWorry(worryCreateDTO);
 

--- a/src/repository/worryRepository.ts
+++ b/src/repository/worryRepository.ts
@@ -1,13 +1,18 @@
 import prisma from "./prismaClient"
 import { worryCreateDTO, worryUpdateDTO} from "../interfaces/worryDTO";
 
-
+// created_at, updated_at 은 디비에 저장시 utc 값으로 저장
+// deadline은 kst 값으로 저장
 
 const createWorry = async(worryCreateDTO: worryCreateDTO) => {
     const d_day = worryCreateDTO.deadline;
-    const date = new Date();
-    const deadline_date = new Date();
-    deadline_date.setDate(date.getDate()+d_day);
+    
+    const date = new Date(); // utc기준 현재시간
+    
+    // moment() = kst기준 현재시간
+    const moment = require('moment');
+    const deadline_date = moment().add(d_day, 'days').format('YYYY-MM-DD');
+
 
     return await prisma.worry.create({
         data: {
@@ -17,7 +22,7 @@ const createWorry = async(worryCreateDTO: worryCreateDTO) => {
             answers: worryCreateDTO.answers,
             created_at: date,
             updated_at: date,
-            deadline: deadline_date,
+            deadline: new Date(deadline_date),
         }
     })
 }

--- a/src/repository/worryRepository.ts
+++ b/src/repository/worryRepository.ts
@@ -6,24 +6,29 @@ import { worryCreateDTO, worryUpdateDTO} from "../interfaces/worryDTO";
 
 const createWorry = async(worryCreateDTO: worryCreateDTO) => {
     const d_day = worryCreateDTO.deadline;
-    
     const date = new Date(); // utc기준 현재시간
+    const moment = require('moment');   // moment() = kst기준 현재시간
+    let deadline_date;
+
+    const createData:any = {
+        template_id: worryCreateDTO.templateId,
+        user_id: worryCreateDTO.userId,
+        title: worryCreateDTO.title,
+        answers: worryCreateDTO.answers,
+        created_at: date,
+        updated_at: date,
+    }
+
+    if(d_day != -1){
+        deadline_date = moment().add(d_day, 'days').format('YYYY-MM-DD');
+        createData.deadline = new Date(deadline_date);
+    }
+    else{
+        createData.deadline = null;
+    }
     
-    // moment() = kst기준 현재시간
-    const moment = require('moment');
-    const deadline_date = moment().add(d_day, 'days').format('YYYY-MM-DD');
-
-
     return await prisma.worry.create({
-        data: {
-            template_id: worryCreateDTO.templateId,
-            user_id: worryCreateDTO.userId,
-            title: worryCreateDTO.title,
-            answers: worryCreateDTO.answers,
-            created_at: date,
-            updated_at: date,
-            deadline: new Date(deadline_date),
-        }
+        data: createData
     })
 }
 

--- a/src/service/worryService.ts
+++ b/src/service/worryService.ts
@@ -65,10 +65,9 @@ const getWorryDetail =async (worryId: number,userId: number) => {
     }
 
 
-    // d-day 계산
+    // d-day 계산 (날짜 차이 계산을 위해 today 와 deadline을 moment 객체로 만들어줌)
     const today = moment(moment().format('YYYY-MM-DD'));
     const deadline = moment(moment(worry.deadline).format('YYYY-MM-DD'));
-    // const deadline = moment(worry.deadline.toISOString().substring(0,10));
     const gap = deadline.diff(today, 'days')
 
     // local time = kst(korean standard time) 는 utc 기준 +9시간이므로 offset 9로 설정
@@ -82,7 +81,7 @@ const getWorryDetail =async (worryId: number,userId: number) => {
         "answers": worry.answers,
         "period": "",
         "updatedAt": kst_updated_at,
-        "deadline": worry.deadline,
+        "deadline": worry.deadline.toISOString().substring(0,10),
         "d-day": gap,
         "finalAnswer": worry.final_answer,
         "review": {

--- a/src/service/worryService.ts
+++ b/src/service/worryService.ts
@@ -5,18 +5,18 @@ import { worryCreateDTO,worryUpdateDTO } from "../interfaces/worryDTO";
 import templateRepository from "../repository/templateRepository";
 const moment = require('moment');
 
-
 const postWorry =async (worryCreateDTO: worryCreateDTO) => {
     const worry = await worryRepository.createWorry(worryCreateDTO);
     if (!worry) {
         throw new ClientException(rm.CREATE_WORRY_FAIL);
     }
-    const today = moment();
 
     const data = {
-        createdAt: today.format('YYYY-MM-DD'),
-        deadline: worry.deadline.toISOString().substring(0,10)
+        createdAt: moment().format('YYYY-MM-DD'),
+        deadline: "데드라인이 없습니다."
     }
+    if(worry.deadline != null)
+        data.deadline = worry.deadline.toISOString().substring(0,10)
 
     return data;
     
@@ -29,7 +29,7 @@ const patchWorry =async (worryUpdateDTO: worryUpdateDTO) => {
     }
 
     const data = {
-        updatedAt: worry.updated_at.toISOString().substring(0,10),
+        updatedAt: moment().format('YYYY-MM-DD'),
     }
 
     return data;
@@ -64,11 +64,18 @@ const getWorryDetail =async (worryId: number,userId: number) => {
         throw new ClientException("고민글 작성자만 조회할 수 있습니다.");
     }
 
-
-    // d-day 계산 (날짜 차이 계산을 위해 today 와 deadline을 moment 객체로 만들어줌)
-    const today = moment(moment().format('YYYY-MM-DD'));
-    const deadline = moment(moment(worry.deadline).format('YYYY-MM-DD'));
-    const gap = deadline.diff(today, 'days')
+    let gap;
+    // (데드라인 존재하는 경우) : gap = d-day에 해당하는 값
+    if (worry.deadline != null){
+        // d-day 계산 (날짜 차이 계산을 위해 today 와 deadline을 moment 객체로 만들어줌)
+        const today = moment(moment().format('YYYY-MM-DD'));
+        const deadline = moment(moment(worry.deadline).format('YYYY-MM-DD'));
+        gap = deadline.diff(today, 'days')
+    }
+    // (데드라인 존재하지 않을 경우) : gap = -1
+    else{
+        gap = -1;
+    }
 
     // local time = kst(korean standard time) 는 utc 기준 +9시간이므로 offset 9로 설정
     const kst_created_at = moment(worry.created_at).utc().utcOffset(9).format('YYYY-MM-DD');
@@ -79,9 +86,9 @@ const getWorryDetail =async (worryId: number,userId: number) => {
         "templateId": worry.template_id,
         "questions": template.questions,
         "answers": worry.answers,
-        "period": "",
+        "period": "아직 고민중인 글입니다.",
         "updatedAt": kst_updated_at,
-        "deadline": worry.deadline.toISOString().substring(0,10),
+        "deadline": "데드라인이 없습니다.",
         "d-day": gap,
         "finalAnswer": worry.final_answer,
         "review": {
@@ -89,10 +96,11 @@ const getWorryDetail =async (worryId: number,userId: number) => {
             "updatedAt": ""
         }
     }
-    if(worry.final_answer == null)
-        data.period = "아직 고민중인 글입니다.";
-    else
+    if(worry.final_answer != null)
         data.period = kst_created_at+"~"+kst_updated_at;
+
+    if(worry.deadline != null)
+        data.deadline = worry.deadline.toISOString().substring(0,10)
 
     return data;
     


### PR DESCRIPTION
## 🔎 관련이슈
<!-- closed #이슈번호 -->
- #21 
## ✨ 변경사항
created_at, updated_at 값을 utc -> kst로 변환하여 response에 표기

## 📃 참고사항
<!-- 참고한 사항이나 참고해야할 사항이 있다면 작성해주세요. -->
deadline의 경우 timestamp가 아닌 date 타입이다.
때문에 new Date()를 사용한 (utc)값이 아닌, moment()를 사용한 현재 로컬 시간(kst) 기준으로 d-day 값을 더하여 deadline 날짜를 계산 후, 해당 값을 디비에 저장해야 한다.