### PR TITLE
[FEAT] login 로직 수정

### DIFF
--- a/src/controller/userController.ts
+++ b/src/controller/userController.ts
@@ -10,85 +10,122 @@ import jwtHandler from "../modules/jwtHandler";
 import axios from 'axios';
 import qs from "qs";
 
-const kakaoLogin_getAuthorizedCode = async (req: Request, res: Response, next: NextFunction) => {
-  try{
-    //인가코드 받기
-    const baseUrl = "https://kauth.kakao.com/oauth/authorize";
-    const config = {
-      client_id: process.env.KAKAO_CLIENT_ID!,
-      redirect_uri: process.env.KAKAO_REDIRECT_URI!,
-      response_type: "code",
-    };
-    const params = new URLSearchParams(config).toString();
+// const kakaoLogin_getAuthorizedCode = async (req: Request, res: Response, next: NextFunction) => {
+//   try{
+//     //인가코드 받기
+//     const baseUrl = "https://kauth.kakao.com/oauth/authorize";
+//     const config = {
+//       client_id: process.env.KAKAO_CLIENT_ID!,
+//       redirect_uri: process.env.KAKAO_REDIRECT_URI!,
+//       response_type: "code",
+//     };
+//     const params = new URLSearchParams(config).toString();
 
-    const finalUrl = `${baseUrl}?${params}`;
-    return res.redirect(finalUrl);
+//     const finalUrl = `${baseUrl}?${params}`;
+//     return res.redirect(finalUrl);
   
-  }catch (error) {
-    next(error);
+//   }catch (error) {
+//     next(error);
+//   }
+
+// };
+// const kakaoLogin_getToken = async (req: Request, res: Response, next: NextFunction) => {
+//   try{
+
+//     if(req.query.error){
+//       throw new ClientException("로그인 실패");
+//     }
+
+//     //토큰 받기
+//     const response = await axios({
+//         method: 'POST',
+//         url: 'https://kauth.kakao.com/oauth/token',
+//         headers:{
+//           'Content-type': 'application/x-www-form-urlencoded;charset=utf-8'
+//         },
+//         data:qs.stringify({//객체를 string 으로 변환
+//             grant_type: 'authorization_code',             //해당 값으로 고정
+//             client_id:process.env.KAKAO_CLIENT_ID,
+//             client_secret:process.env.KAKAO_SECRET_KEY,  //보안 강화를 위함 (필수값은 아님)
+//             redirectUri:process.env.KAKAO_REDIRECT_URI,
+//             code:req.query.code,                         //kakaoLogin_getAuthorizeCode 를 통해 query string 으로 받은 인가 코드
+//         })
+//     })
+//     const token = response.data
+//     console.log(token)
+    
+
+//     //발급받은 토큰을 사용해서 카카오 유저 정보 가져오기
+//     const user = await kakaoLogin_getUserKakaoInfo(token);
+//     if(!user)
+//       return res.redirect('/kakao/login');
+    
+//     return await serviceLogin(req,res,next,user);
+
+//     // return res.status(sc.OK).send(success(statusCode.OK, rm.KAKAO_LOGIN_SUCCESS, response.data));
+
+
+//   } catch (error) {
+//     next(error);
+// }
+// }
+
+// const kakaoLogin_getUserKakaoInfo =async (token: any) => {
+      
+//   // 엑세스 토큰을 제대로 전달받은 경우
+//     if ("access_token" in token) {
+//       const { access_token } = token;
+//       // console.log(access_token);
+//       const response = await axios({
+//         method: 'GET',
+//         url: 'https://kapi.kakao.com/v2/user/me',
+//         headers:{
+//           'Authorization': `Bearer ${access_token}`,
+//           'Content-type': 'application/x-www-form-urlencoded;charset=utf-8'
+//         },
+//       })
+//       // console.log(response.data)
+//       return response.data;
+//     } 
+//     // 엑세스 토큰이 없으면 로그인페이지로 리다이렉트
+//     else {
+//       return null;
+//     }
+
+// }
+
+const kakaoLogin =async (req: Request, res:Response, next:NextFunction) => {
+  const token = req.body
+
+  // 엑세스 토큰이 없으면 에러 반환
+  if (!("accessToken" in token)){
+    return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.BAD_REQUEST));
   }
 
-};
-const kakaoLogin_getToken = async (req: Request, res: Response, next: NextFunction) => {
+  const { accessToken } = token;
   try{
-
-    if(req.query.error){
-      throw new ClientException("로그인 실패");
-    }
-
-    //토큰 받기
     const response = await axios({
-        method: 'POST',
-        url: 'https://kauth.kakao.com/oauth/token',
-        headers:{
-          'Content-type': 'application/x-www-form-urlencoded;charset=utf-8'
-        },
-        data:qs.stringify({//객체를 string 으로 변환
-            grant_type: 'authorization_code',             //해당 값으로 고정
-            client_id:process.env.KAKAO_CLIENT_ID,
-            client_secret:process.env.KAKAO_SECRET_KEY,  //보안 강화를 위함 (필수값은 아님)
-            redirectUri:process.env.KAKAO_REDIRECT_URI,
-            code:req.query.code,                         //kakaoLogin_getAuthorizeCode 를 통해 query string 으로 받은 인가 코드
-        })
+      method: 'GET',
+      url: 'https://kapi.kakao.com/v2/user/me',
+      headers:{
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-type': 'application/x-www-form-urlencoded;charset=utf-8'
+      },
     })
-    const token = response.data
 
-    //발급받은 토큰을 사용해서 카카오 유저 정보 가져오기
-    const user = await kakaoLogin_getUserKakaoInfo(token);
-    if(!user)
-      return res.redirect('/kakao/login');
-    
-    return await serviceLogin(req,res,next,user);
+    // console.log(response.data)
+    return await serviceLogin(req,res,next,response.data);
 
-    // return res.status(sc.OK).send(success(statusCode.OK, rm.KAKAO_LOGIN_SUCCESS, response.data));
+  }catch(error:any){
 
-
-  } catch (error) {
-    next(error);
-}
-}
-
-const kakaoLogin_getUserKakaoInfo =async (token: any) => {
-      
-  // 엑세스 토큰을 제대로 전달받은 경우
-    if ("access_token" in token) {
-      const { access_token } = token;
-      // console.log(access_token);
-      const response = await axios({
-        method: 'GET',
-        url: 'https://kapi.kakao.com/v2/user/me',
-        headers:{
-          'Authorization': `Bearer ${access_token}`,
-          'Content-type': 'application/x-www-form-urlencoded;charset=utf-8'
-        },
-      })
-      // console.log(response.data)
-      return response.data;
-    } 
-    // 엑세스 토큰이 없으면 로그인페이지로 리다이렉트
-    else {
-      return null;
+    //토큰이 유효하지 않은 경우
+    if(error.response.data.msg == "this access token does not exist"){
+      return res.status(sc.UNAUTHORIZED).send(fail(sc.UNAUTHORIZED, rm.INVALID_TOKEN));
     }
+
+    return res.status(error.response.status).send(fail(error.response.status, error.response.data.msg));
+
+  }
 
 }
 
@@ -159,7 +196,7 @@ const createUser = async (req: Request, res: Response) => {
       return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.SIGNUP_FAIL));
     }
   
-    //accessToken 생성
+    //local accessToken 생성
     const accessToken = jwtHandler.sign(data.id);
   
     const result = {
@@ -194,7 +231,8 @@ export default{
     getUserById,
     createUser,
     loginUser,
-    kakaoLogin_getAuthorizedCode,
-    kakaoLogin_getToken,
+    // kakaoLogin_getAuthorizedCode,
+    // kakaoLogin_getToken,
+    kakaoLogin,
     serviceLogin,
 }

--- a/src/router/userRouter.ts
+++ b/src/router/userRouter.ts
@@ -8,8 +8,11 @@ import validate from "../middlewares/validate";
 
 const router = Router();
 
-router.get("/kakao/login", userController.kakaoLogin_getAuthorizedCode)
-router.get("/kakao/token", userController.kakaoLogin_getToken)
+// router.get("/kakao/login", userController.kakaoLogin_getAuthorizedCode)
+// router.get("/kakao/token", userController.kakaoLogin_getToken)
+
+router.get("/kakao/login", userController.kakaoLogin)
+
 
 router.get("/:userId",
     auth,


### PR DESCRIPTION
## 🔎 관련이슈
<!-- closed #이슈번호 -->
- #52 

## ✨ 변경사항
카카오에서 인가코드 받기 -> 받은 인가코드로 액세스토큰 받기 -> 해당 액세스토큰으로 카카오샤용저 정보 가져오기 -> 해당 정보를 우리디비에 저장하기
이 전체 과정을 다 서버쪽에서 처리하는 로직으로 구현하였으나, 앞의 두 부분은 클라단에서 구현하기로.
클라에서 카카오 액세스토큰을 서버로 넘겨주어 뒤의 두 단계만 서버에서 처리하는 방식으로 로직 수정

## 📃 참고사항
<!-- 참고한 사항이나 참고해야할 사항이 있다면 작성해주세요. -->
