### PR TITLE
[FIX] 토큰 재발급

### DIFF
--- a/src/controller/userController.ts
+++ b/src/controller/userController.ts
@@ -231,6 +231,12 @@ const refreshToken = async (req: Request, res: Response, next: NextFunction) => 
       return res.status(sc.OK).send(success(statusCode.OK, rm.REFRESH_TOKEN_SUCCESS, new_access_token));
 
     }
+    
+    const data = {
+      "accessToken": accessToken
+    }
+
+    return res.status(sc.OK).send(success(statusCode.OK, "유효한 토큰입니다. 재발급이 불필요합니다.",data));
 
   }catch(error){
     next(error)

--- a/src/service/userService.ts
+++ b/src/service/userService.ts
@@ -35,7 +35,12 @@ const refreshToken =async (refreshToken:string) => {
         throw new ClientException("refresh token not found in database");
     }
 
-    return jwtHandler.access(user.user_id);
+    const token = jwtHandler.access(user.user_id);
+    const data = {
+        "accessToken": token
+    }
+
+    return data;
 }
 
 


### PR DESCRIPTION
## 🔎 관련이슈
<!-- closed #이슈번호 -->

## ✨ 변경사항
- 토큰 재발급시 기존의 응답 형식 아래와 같이 수정
```
{
   "status":200,
   "success":true,                                         
   "message":"토큰 재발급 성공",
   "data": {
      "accessToken": 재발급한 액세스토큰
   }
}
```
- 토큰 재발급 불필요한 경우(토큰이 아직 유효한 경우) 아래와 같은 형식으로 응답하게끔 수정
```
{
  "status": 200,
  "success": true,
  "message": "유효한 토큰입니다. 재발급이 불필요합니다.",
  "data": {
    "accessToken": 기존의 유효한 토큰
  }
}
```



## 📃 참고사항
<!-- 참고한 사항이나 참고해야할 사항이 있다면 작성해주세요. -->
