### PR TITLE
[FEAT] 유저 used template 저장

### DIFF
--- a/src/repository/worryRepository.ts
+++ b/src/repository/worryRepository.ts
@@ -5,8 +5,8 @@ import { finalAnswerCreateDTO, worryUpdateDTO } from "../interfaces/DTO/worryDTO
 // deadline은 kst 값으로 저장
 
 const createWorry = async(worryCreateDAO: worryCreateDAO) => {
-  
-    return await prisma.worry.create({
+    
+    const createdWorry = prisma.worry.create({
         data: {
             template_id: worryCreateDAO.templateId,
             user_id: worryCreateDAO.userId,
@@ -17,6 +17,37 @@ const createWorry = async(worryCreateDAO: worryCreateDAO) => {
             deadline: worryCreateDAO.deadlineDate
         }
     })
+
+    const user = await prisma.user.findUnique({
+        select:{
+            used_template: true
+        },
+        where:{
+            id: worryCreateDAO.userId
+        }
+    })
+    if(!user){
+        return null
+    }
+    
+    const usedTemplate = user.used_template    
+    // 이미 usedTemplate에 해당 templateId가 저장되어 있는 경우 (usedTemplate update 필요 x)
+    if(usedTemplate != null && usedTemplate.includes(worryCreateDAO.templateId)){
+        return await prisma.$transaction([createdWorry])
+    }
+
+    const updateUsedTemplate =  prisma.user.update({
+        where: {
+            id: worryCreateDAO.userId
+        },
+        data: {
+            used_template: {
+                push: worryCreateDAO.templateId
+            }
+        }
+    })
+
+    return await prisma.$transaction([createdWorry,updateUsedTemplate])
 }
 
 const updateWorry = async(worryUpdateDTO: worryUpdateDTO) => {

--- a/src/service/worryService.ts
+++ b/src/service/worryService.ts
@@ -30,11 +30,13 @@ const postWorry =async (worryCreateDTO: worryCreateDTO) => {
     }
     // console.log(worryCreateDAO)
 
-    const worry = await worryRepository.createWorry(worryCreateDAO);
-    if (!worry) {
+    const result = await worryRepository.createWorry(worryCreateDAO);
+    if (!result) {
         throw new ClientException(rm.CREATE_WORRY_FAIL);
     }
 
+    // result[0]: createdWorry | result[1]: updatedUsedTemplate 
+    const worry = result[0]
     const data = {
         createdAt: moment(worry.created_at).utc().utcOffset(9).format('YYYY-MM-DD'),
         deadline: "데드라인이 없습니다."


### PR DESCRIPTION
## 🔎 관련이슈
<!-- closed #이슈번호 -->

## ✨ 변경사항
유저가 사용한 templateId를 usedTemplate 배열에 저장

## 📃 참고사항
<!-- 참고한 사항이나 참고해야할 사항이 있다면 작성해주세요. -->
기존의 usedTemplate 배열에 새로운 templateId를 추가하는 방법:
- `push`: Push values to the end of an embedded list of composite types
```
const product = prisma.product.update({
  where: {
    id: '62de6d328a65d8fffdae2c18',
  },
  data: {
    photos: {
       // Push a photo to the end of the photos list
       push: [{ height: 100, width: 200, url: '1.jpg' }],
    },
  },
})
```

https://github.com/prisma/prisma/discussions/2614
https://www.prisma.io/docs/concepts/components/prisma-client/composite-types#changing-multiple-composite-types