### PR TITLE
[FIX] 유저로그인 및 회원가입, 로그아웃 수정

### DIFF
--- a/src/interfaces/DTO/userDTO.ts
+++ b/src/interfaces/DTO/userDTO.ts
@@ -5,6 +5,7 @@ interface userCreateDTO {
     ageRange: string | null;
     gender: string | null;
     email: string | null;
+    refreshToken: string;
 }
 
 

--- a/src/repository/tokenRepository.ts
+++ b/src/repository/tokenRepository.ts
@@ -44,10 +44,13 @@ const updateRefreshTokenById = async (userId: number, token:string) => {
     });
 };
 
-const deleteRefreshTokenById = async (userId: number) => {
-    return await prisma.token.delete({
+const disableRefreshTokenById = async (userId: number) => {
+    return await prisma.token.update({
         where: {
             user_id: userId
+        },
+        data:{
+            refresh_token: ""
         }
     });
 };
@@ -58,6 +61,6 @@ export default {
     findRefreshTokenById,
     findIdByRefreshToken,
     updateRefreshTokenById,
-    deleteRefreshTokenById
+    disableRefreshTokenById
 
 }

--- a/src/repository/userRepository.ts
+++ b/src/repository/userRepository.ts
@@ -38,6 +38,11 @@ const createUser = async(userCreateDTO:userCreateDTO) => {
             created_at: new Date(),
             updated_at: new Date(),
 
+            token:{
+                create:{
+                    refresh_token: userCreateDTO.refreshToken
+                }
+            }
         }
     })
 }

--- a/src/repository/worryRepository.ts
+++ b/src/repository/worryRepository.ts
@@ -1,6 +1,7 @@
 import prisma from "./prismaClient"
 import { worryCreateDAO,deadlineUpdateDAO } from "../interfaces/DAO/worryDAO";
 import { finalAnswerCreateDTO, worryUpdateDTO } from "../interfaces/DTO/worryDTO";
+import { wrap } from "module";
 // created_at, updated_at 은 디비에 저장시 utc 값으로 저장
 // deadline은 kst 값으로 저장
 
@@ -67,11 +68,19 @@ const updateWorry = async(worryUpdateDTO: worryUpdateDTO) => {
 
 const deleteWorry = async(worryId:number) => {
 
-    return await prisma.worry.delete({
+    const deleteReview = prisma.review.delete({
+        where:{
+            worry_id: worryId
+        }
+    })
+
+    const deleteWorry = prisma.worry.delete({
         where: {
             id: worryId
         }
     })
+
+    return await prisma.$transaction([deleteReview,deleteWorry])
 
 }
 

--- a/src/service/authService.ts
+++ b/src/service/authService.ts
@@ -18,7 +18,7 @@ const serviceLogin = async (provider:string, user:any) => {
       foundUser = await userService.getUserByKakaoId(id);
 
   
-      //가입하지 않은 회원일 경우, 회원가입 진행
+      //신규 회원일 경우, 회원가입 진행
       if(!foundUser){
         
         //필수 동의만 했을 경우
@@ -33,7 +33,8 @@ const serviceLogin = async (provider:string, user:any) => {
             userCreateDTO.ageRange = kakao_account.age_range
         if(kakao_account.gender)
             userCreateDTO.gender = kakao_account.gender
-
+        
+        //신규회원일 경우
         isNew = true
       }
     }//kakao
@@ -84,20 +85,20 @@ const serviceLogin = async (provider:string, user:any) => {
 
     // local refreshToken 먼저 발급후, 회원가입시 같이 DB에 저장
     const refreshToken = jwtHandler.refresh();
-    // 새로운 회원일 경우 회원가입 진행
+    // 신규회원일 경우 회원가입 진행
     if(isNew){
       userCreateDTO.refreshToken = refreshToken;
       const createdUser = await userService.createUser(userCreateDTO);
       foundUser = createdUser
     }
 
-    // 기존 유저, 새로운 유저 둘 다 존재하지 않을 시
+    // 신규회원,기존회원 둘 다 존재하지 않을 시
     if(!foundUser){
       throw new ClientException("로그인 및 회원가입 실패");
     }
 
 
-    // 기존 유저의 경우 이전 refresh token을 갱신하여 DB에 저장
+    // 기존회원의 경우 이전 refresh token을 갱신하여 DB에 저장
     if(!isNew){
       const updatedToken = await tokenRepository.updateRefreshTokenById(foundUser.id,refreshToken);
       if(!updatedToken){

--- a/src/service/authService.ts
+++ b/src/service/authService.ts
@@ -99,7 +99,10 @@ const serviceLogin = async (provider:string, user:any) => {
 
     // 기존 유저의 경우 이전 refresh token을 갱신하여 DB에 저장
     if(!isNew){
-      await tokenRepository.updateRefreshTokenById(foundUser.id,refreshToken);
+      const updatedToken = await tokenRepository.updateRefreshTokenById(foundUser.id,refreshToken);
+      if(!updatedToken){
+        throw new ClientException("refresh token 갱신 실패");
+      }
     }
 
     

--- a/src/service/worryService.ts
+++ b/src/service/worryService.ts
@@ -80,10 +80,10 @@ const deleteWorry =async (worryId: number,userId: number) => {
     if (worry.user_id != userId) {
       throw new ClientException("고민글 작성자만 삭제할 수 있습니다.");
     }
-    const review = await reviewRepository.findreviewById(worryId);
-    if(review){
-        await reviewRepository.deleteReviewById(worryId);
-    }
+    // const review = await reviewRepository.findreviewById(worryId);
+    // if(review){
+    //     await reviewRepository.deleteReviewById(worryId);
+    // }
 
     await worryRepository.deleteWorry(worryId);
 }


### PR DESCRIPTION
## 🔎 관련이슈
<!-- closed #이슈번호 -->

## ✨ 변경사항
 [로그인]
신규회원 로그인(회원가입)
**변경 전**: createUser, createRefreshToken 따로 처리
`transaction을 적용하지 않아 1)유저를 생성하여 디비에 저장, 2)리프레쉬토큰 생성하여 디비에 저장하는 두 과정이 atomic하게 이루어짐을 보장할 수 없었음.`
문제상황: 유저를 생성하여 디비에 저장했지만, 에러 발생하여 2) 과정이 수행되지 못한 경우
해당 상황에서는 롤백하여 유저를 생성하기 이전 상태로 간 뒤, 에러를 반환해야 한다.
때문에 아래와 같이 수정
=> **변경 후**: createUser시 prisma의 nested query 사용하여 refresh token도 같이 디비에 저장하여 두 과정이 atomic하게 이루어지도록

> 이때 prisma의 $transaction API 를 사용하지 않고 nested query를 사용한 이유는,
resfresh token을 저장할 때, token 테이블에 저장하게 되는데 이때 user_id가 필요.
해당 user_id는 유저를 생성해야 발급되는 id. 즉, 아래 상황에 해당.
`if operation A relies on the ID generated by operation B, use nested writes`
https://www.prisma.io/docs/guides/performance-and-optimization/prisma-client-transactions-guide#nested-writes

기존회원 로그인
디비에 저장되어 있는 refresh Token 갱신. 따로 변경사항은 없음.

[로그아웃]
**변경 전**: 로그아웃시 해당 유저의 refresh Token `삭제` 
`refresh Token을 삭제할 경우, 로그아웃 이후 재로그인시 token테이블에서 user_id에 해당하는 refresh token값을 갱신할 수가 없다. `
=> **변경 후**: 로그아웃시 해당 유저의 refresh Token `빈 스트링` 처리

 
## 📃 참고사항
<!-- 참고한 사항이나 참고해야할 사항이 있다면 작성해주세요. -->
