### PR TITLE
[FIX] 고민목록 조회하기 API에 pagination 추가

### DIFF
--- a/src/controller/worryController.ts
+++ b/src/controller/worryController.ts
@@ -94,9 +94,10 @@ const patchDeadline = async (req: Request, res: Response, next: NextFunction) =>
 const getWorryList = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const { isSolved } = req.params;
+        const { page, limit } = req.query;
         const { userId }= req.body;
 
-        const data = await worryService.getWorryList(+isSolved,userId);
+        const data = await worryService.getWorryList(+isSolved, +page!, +limit!, userId);
 
         return res.status(sc.OK).send(success(statusCode.OK, rm.GET_WORRY_LIST_SUCCESS,data));
 

--- a/src/repository/worryRepository.ts
+++ b/src/repository/worryRepository.ts
@@ -130,7 +130,7 @@ const updateDeadline = async(deadlineUpdateDAO: deadlineUpdateDAO) => {
     })
 }
 
-const findWorryListSolved = async(userId: number) => {
+const findAllWorryListSolved = async(userId: number) => {
 
     return await prisma.worry.findMany({
         select:{
@@ -148,12 +148,37 @@ const findWorryListSolved = async(userId: number) => {
             }
         },
         orderBy:{
-            created_at: 'asc'
+            updated_at: 'desc'
         } 
     })
 }
 
-const findWorryListUnsolved = async(userId: number) => {
+const findWorryListSolved = async(userId: number, page: number, limit: number) => {
+
+    return await prisma.worry.findMany({
+        select:{
+            id:true,
+            user_id:true,
+            template_id:true,
+            title:true,
+            created_at:true,
+            updated_at:true
+        },    
+        where: {
+            user_id: userId,
+            final_answer:{
+                not: null
+            }
+        },
+        skip: (page - 1) * limit,
+        take: limit,
+        orderBy:{
+            updated_at: 'desc'
+        } 
+    })
+}
+
+const findWorryListUnsolved = async(userId: number, page: number, limit: number) => {
 
     return await prisma.worry.findMany({
         select:{
@@ -165,9 +190,11 @@ const findWorryListUnsolved = async(userId: number) => {
         where: {
             user_id: userId,
             final_answer: null
-        }, 
+        },
+        skip: (page - 1) * limit,
+        take: limit, 
         orderBy:{
-            created_at: 'asc'
+            created_at: 'desc'
         }
     })
 }
@@ -190,7 +217,7 @@ const findWorryListByTemplate = async(templateId: number,userId: number) => {
             }
         }, 
         orderBy:{
-            created_at: 'asc'
+            created_at: 'desc'
         }
     })
 }
@@ -199,11 +226,11 @@ export default {
     createWorry,
     updateWorry,
     deleteWorry,
-    // deleteWorryByUserId,
     findWorryById,
     createFinalAnswer,
     updateDeadline,
     findWorryListSolved,
+    findAllWorryListSolved,
     findWorryListUnsolved,
     findWorryListByTemplate
 

--- a/src/repository/worryRepository.ts
+++ b/src/repository/worryRepository.ts
@@ -217,7 +217,7 @@ const findWorryListByTemplate = async(templateId: number,userId: number) => {
             }
         }, 
         orderBy:{
-            created_at: 'desc'
+            updated_at: 'desc'
         }
     })
 }

--- a/src/router/worryRouter.ts
+++ b/src/router/worryRouter.ts
@@ -77,12 +77,21 @@ router.patch("/deadline",
 
 
 
-router.get("/list/:isSolved",
-    auth,
-    validate,
-    worryController.getWorryList,
-);
+// router.get("/list/:isSolved",
+//     auth,
+//     validate,
+//     worryController.getWorryList,
+// );
 
+router.get("/:isSolved/list",
+auth,
+[
+    query('page').notEmpty().withMessage("query string 에 'page' 값이 존재하지 않습니다"),
+    query('limit').notEmpty().withMessage("query string 에 'limit' 값이 존재하지 않습니다")
+],
+validate,
+worryController.getWorryList,
+);
 
 
 

--- a/src/service/worryService.ts
+++ b/src/service/worryService.ts
@@ -219,12 +219,12 @@ const patchDeadline =async (deadlineUpdateDTO: deadlineUpdateDTO) => {
 
 }
 
-const getWorryList =async (isSolved: number, userId: number) => {
+const getWorryList =async (isSolved: number, page: number, limit: number, userId: number) => {
     let worry = null;
     if(isSolved)
-        worry = await worryRepository.findWorryListSolved(userId);
+        worry = await worryRepository.findWorryListSolved(userId,page,limit);
     else
-        worry = await worryRepository.findWorryListUnsolved(userId);
+        worry = await worryRepository.findWorryListUnsolved(userId,page,limit);
 
     if (!worry) {
         throw new ClientException(rm.GET_WORRY_LIST_FAIL);
@@ -247,7 +247,7 @@ const getWorryList =async (isSolved: number, userId: number) => {
 const getWorryListByTemplate =async (templateId: number, userId: number) => {
     let worry;
     if(templateId == 0)
-        worry = await worryRepository.findWorryListSolved(userId);
+        worry = await worryRepository.findAllWorryListSolved(userId);
     else
         worry = await worryRepository.findWorryListByTemplate(templateId,userId);
     


### PR DESCRIPTION
## 🔎 관련이슈
<!-- closed #이슈번호 -->

## ✨ 변경사항
고민목록 조회하기 API 
수정 전: `/worry/list/:isSolved`
수정 후: `/worry/:isSolved/list?page= & limit=`

+) 고민 목록 조회시, 
고민중인 목록(원석)은 고민생성 시점 기준으로 최신순
고민완료 목록(보석)은 고민끝낸 시점 기준으로 최신순으로 정렬하여 반환

## 📃 참고사항
<!-- 참고한 사항이나 참고해야할 사항이 있다면 작성해주세요. -->
