### PR TITLE
[FIX] 관리자는 회원탈퇴 불가하게

### DIFF
--- a/src/constants/responseMessage.ts
+++ b/src/constants/responseMessage.ts
@@ -9,6 +9,7 @@ export default {
   SIGNUP_FAIL: "회원 가입 실패",
   UNREGISTER_SUCCESS: "회원 탈퇴 성공",
   UNREGISTER_FAIL: "회원 탈퇴 실패",
+  DEV_USER_UNREGISTER_IMPOSSIBLE: "관리자 계정은 회원탈퇴 불가입니다.",
   LOGIN_SUCCESS: "로그인 성공",
   LOGIN_FAIL: "로그인 실패",
   LOGOUT_SUCCESS: "로그아웃 성공",

--- a/src/controller/authController.ts
+++ b/src/controller/authController.ts
@@ -151,6 +151,9 @@ const kakaoLogin_getAuthorizedCode = async (req: Request, res: Response, next: N
   const serviceUnregister =async (req: Request, res:Response, next:NextFunction) => {
     try{
       const { userId } = req.body;
+      if(userId == 11){
+        return res.status(sc.BAD_REQUEST).send(success(sc.BAD_REQUEST, rm.DEV_USER_UNREGISTER_IMPOSSIBLE));  
+      }
       await authService.serviceUnregister(userId);
  
 

--- a/src/router/authRouter.ts
+++ b/src/router/authRouter.ts
@@ -35,8 +35,8 @@ router.post("/logout",
     authController.serviceLogout
 )
 
-router.post("/unregister",
- 
+router.delete("/unregister",
+    auth,
     authController.serviceUnregister
 )
 


### PR DESCRIPTION
## 🔎 관련이슈
<!-- closed #이슈번호 -->

## ✨ 변경사항
- 관리자는 회원탈퇴 불가하게 수정
- 회원탈퇴 API http method `POST -> DELETE`로 수정
## 📃 참고사항
<!-- 참고한 사항이나 참고해야할 사항이 있다면 작성해주세요. -->
