### PR TITLE
[FIX] review가 없는경우 delete review, delete worry transaction불가 수정

### DIFF
--- a/src/repository/worryRepository.ts
+++ b/src/repository/worryRepository.ts
@@ -66,7 +66,7 @@ const updateWorry = async(worryUpdateDTO: worryUpdateDTO) => {
     })
 }
 
-const deleteWorry = async(worryId:number) => {
+const deleteWorryWithReview = async(worryId:number) => {
 
     const deleteReview = prisma.review.delete({
         where:{
@@ -84,15 +84,16 @@ const deleteWorry = async(worryId:number) => {
 
 }
 
-// const deleteWorryByUserId = async(userId:number) => {
+const deleteWorryWithoutReview = async(worryId:number) => {
 
-//     return await prisma.worry.deleteMany({
-//         where: {
-//             user_id: userId
-//         }
-//     })
+    return await prisma.worry.delete({
+        where: {
+            id: worryId
+        }
+    })
 
-// }
+}
+
 
 const findWorryById = async(worryId:number) => {
 
@@ -225,7 +226,8 @@ const findWorryListByTemplate = async(templateId: number,userId: number) => {
 export default {
     createWorry,
     updateWorry,
-    deleteWorry,
+    deleteWorryWithReview,
+    deleteWorryWithoutReview,
     findWorryById,
     createFinalAnswer,
     updateDeadline,

--- a/src/service/worryService.ts
+++ b/src/service/worryService.ts
@@ -80,12 +80,13 @@ const deleteWorry =async (worryId: number,userId: number) => {
     if (worry.user_id != userId) {
       throw new ClientException("고민글 작성자만 삭제할 수 있습니다.");
     }
-    // const review = await reviewRepository.findreviewById(worryId);
-    // if(review){
-    //     await reviewRepository.deleteReviewById(worryId);
-    // }
 
-    await worryRepository.deleteWorry(worryId);
+    const review = await reviewRepository.findreviewById(worryId);
+    if(!review){
+        return await worryRepository.deleteWorryWithoutReview(worryId);
+    }
+
+    return await worryRepository.deleteWorryWithReview(worryId);
 }
 
 const getWorryDetail =async (worryId: number,userId: number) => {


### PR DESCRIPTION
## 🔎 관련이슈
<!-- closed #이슈번호 -->

## ✨ 변경사항
`수정전`: worryRepository.ts 에서의 deleteWorry 함수호출
`문제`: 해당 함수는 리뷰삭제와 고민글 삭제를 하나의 transaction으로 묶고 있었음.
=> 때문에 리뷰가 없는 고민글의 경우, 리뷰삭제부분에서 오류 발생
`수정후`:  deleteWorryWithReview, deleteWorryWithoutReview 함수로 분리

## 📃 참고사항
<!-- 참고한 사항이나 참고해야할 사항이 있다면 작성해주세요. -->
