### PR TITLE
[FIX] 에러 존재시 에러반환하게

### DIFF
--- a/src/controller/authController.ts
+++ b/src/controller/authController.ts
@@ -130,8 +130,8 @@ const kakaoLogin_getAuthorizedCode = async (req: Request, res: Response, next: N
       // - 기존회원이 로그인한 경우
       return res.status(sc.OK).send(success(sc.OK, rm.LOGIN_SUCCESS, data.result));  
     
-    } catch (err) {
-      console.log("Err", err)
+    } catch (error) {
+      next(error)
     }
   }
 


### PR DESCRIPTION
## 🔎 관련이슈
<!-- closed #이슈번호 -->

## ✨ 변경사항
애플로그인에서 에러발생시 에러를 반환하지 않고 무한로딩되어 time out 되는 문제 존재
authController단 try catch 문에서 catch문 내에 next(error); 를 해주지 않아서 발생하였다,,!
추가로 authService단에서 jwt.verify시 apple의 jwt토큰의 에러 핸들링도 해주기 위해, 해당 부분을 try catch 문으로 감싸주고
에서 발생시, catch문에서 clientException을 throw 하게끔 수정하였다.


## 📃 참고사항
<!-- 참고한 사항이나 참고해야할 사항이 있다면 작성해주세요. -->
