### PR TITLE
[FIX] 고민상세조회 API 에서 review response 수정

### DIFF
--- a/src/controller/alarmController.ts
+++ b/src/controller/alarmController.ts
@@ -9,6 +9,8 @@ import alarmService from "../service/alarmService";
 const setFinishedAlarm = async(req: Request, res: Response, next: NextFunction) => {
     try{
         const { templateId, userId } = req.body;
+
+        console.log(userId)
         const user = await userService.getUserById(userId);
         const userName = user.name;
         const token = await tokenService.getDeviceToken(userId);

--- a/src/service/worryService.ts
+++ b/src/service/worryService.ts
@@ -103,9 +103,6 @@ const getWorryDetail =async (worryId: number,userId: number) => {
 
     const review = await reviewRepository.findreviewById(worry.id);
 
-    
-
-
     const gap = calculate_d_day(worry.deadline);
    
 
@@ -123,20 +120,25 @@ const getWorryDetail =async (worryId: number,userId: number) => {
         "deadline": "데드라인이 없습니다.",
         "d-day": gap,
         "finalAnswer": worry.final_answer,
-        "review": null
-    }
-
-    // if(!review)
-    //     data.review = "등록된 리뷰가 없습니다."
-    if(review != null){
-        data.review = {
-            "content" : review.content,
-            "updatedAt" : moment(review.updated_at).utc().utcOffset(9).format('YYYY-MM-DD')
+        "review":{
+            "content" : null,
+            "updatedAt": null
         }
     }
+
    
-    if(worry.final_answer != null)
+    // 최종 결정 내린 고민
+    if(worry.final_answer != null){
         data.period = kst_created_at+" ~ "+kst_updated_at;
+        data.review.updatedAt = kst_updated_at
+    }
+
+    // 최종 결정 이후
+    // 리뷰 작성한 경우
+    if(review != null){
+        data.review.content = review.content,
+        data.review.updatedAt = moment(review.updated_at).utc().utcOffset(9).format('YYYY-MM-DD')
+    }
 
     if(worry.deadline != null)
         data.deadline = worry.deadline.toISOString().substring(0,10)


### PR DESCRIPTION
## 🔎 관련이슈
<!-- closed #이슈번호 -->

## ✨ 변경사항
해당 요청사항 반영 

`해결된(캐낸) 고민인데 review가 작성되지 않은 글`일 경우,
“review”의 값이 이하처럼 오게 해주세요 🥺

```json
"review": {
    "content": null,  // 아직 review를 안 썼으니까.. ""거나 null이거나.. blank 값이겠죠!
    "updatedAt": "2023-12-17" // 아직 review를 안 썼으니까.. '고민이 해결된(캐내진) 날짜'겠죠!
}
```

## 📃 참고사항
<!-- 참고한 사항이나 참고해야할 사항이 있다면 작성해주세요. -->
