### PR TITLE
[FIX] 고민상세조회, 고민생성, 데드라인수정 API

### DIFF
--- a/src/service/worryService.ts
+++ b/src/service/worryService.ts
@@ -35,6 +35,8 @@ const postWorry =async (worryCreateDTO: worryCreateDTO) => {
         throw new ClientException(rm.CREATE_WORRY_FAIL);
     }
 
+    const gap = calculate_d_day(deadlineDate)
+
     const data:any = {
         worryId: worry.id,
         title: worry.title,
@@ -42,12 +44,11 @@ const postWorry =async (worryCreateDTO: worryCreateDTO) => {
         answers: worry.answers,
         createdAt: moment(worry.created_at).utc().utcOffset(9).format('YYYY-MM-DD'),
         deadline: "데드라인이 없습니다.",
-        dDay: -888
+        dDay: gap
     }
     
     if(worry.deadline != null){
         data.deadline = worry.deadline.toISOString().substring(0,10)
-        data.dDay = deadline
     }
 
     return data;

--- a/src/service/worryService.ts
+++ b/src/service/worryService.ts
@@ -200,6 +200,14 @@ const patchFinalAnswer =async (finalAnswerCreateDTO: finalAnswerCreateDTO) => {
 }
 
 const patchDeadline =async (deadlineUpdateDTO: deadlineUpdateDTO) => {
+    const worry = await worryRepository.findWorryById(deadlineUpdateDTO.worryId)
+    if(!worry){
+        throw new ClientException("해당 id의 고민글이 존재하지 않습니다.");
+    }
+    if (worry.user_id != deadlineUpdateDTO.userId) {
+        throw new ClientException("고민글 작성자만 데드라인을 수정할 수 있습니다.");
+    }
+
     
     const d_day = deadlineUpdateDTO.dayCount;
     const moment = require('moment');   // moment() = kst기준 현재시간
@@ -219,22 +227,19 @@ const patchDeadline =async (deadlineUpdateDTO: deadlineUpdateDTO) => {
     const gap = calculate_d_day(deadlineDate)
 
 
+    const updatedWorry = await worryRepository.updateDeadline(deadlineUpdateDAO);
+    if (!updatedWorry) {
+        throw new ClientException(rm.UPDATE_DEADLINE_FAIL);
+    }
 
-    const worry = await worryRepository.updateDeadline(deadlineUpdateDAO);
-    if (!worry) {
-        throw new ClientException(rm.MAKE_FINAL_ANSWER_FAIL);
-    }
-    if (worry.user_id != deadlineUpdateDTO.userId) {
-        throw new ClientException("고민글 작성자만 데드라인을 수정할 수 있습니다.");
-    }
     
     const data = {
         "deadline": "데드라인이 없습니다.",
         "dDay": gap,
     }
 
-    if(worry.deadline != null)
-        data.deadline = worry.deadline.toISOString().substring(0,10)
+    if(updatedWorry.deadline != null)
+        data.deadline = updatedWorry.deadline.toISOString().substring(0,10)
 
 
     return data;    

--- a/src/service/worryService.ts
+++ b/src/service/worryService.ts
@@ -127,17 +127,18 @@ const getWorryDetail =async (worryId: number,userId: number) => {
         "updatedAt": kst_updated_at,
         "deadline": "데드라인이 없습니다.",
         "dDay": gap,
-        "finalAnswer": worry.final_answer,
+        "finalAnswer": "",
         "review":{
-            "content" : null,
-            "updatedAt": null
+            "content" : "",
+            "updatedAt": ""
         }
     }
 
    
     // 최종 결정 내린 고민
     if(worry.final_answer != null){
-        data.period = kst_created_at+" ~ "+kst_updated_at;
+        data.finalAnswer = worry.final_answer
+        data.period = kst_created_at+" ~ "+kst_updated_at
         data.review.updatedAt = kst_updated_at
     }
 
@@ -208,7 +209,6 @@ const patchDeadline =async (deadlineUpdateDTO: deadlineUpdateDTO) => {
         throw new ClientException("고민글 작성자만 데드라인을 수정할 수 있습니다.");
     }
 
-    
     const d_day = deadlineUpdateDTO.dayCount;
     const moment = require('moment');   // moment() = kst기준 현재시간
     


### PR DESCRIPTION
## 🔎 관련이슈
<!-- closed #이슈번호 -->

## ✨ 변경사항
- 고민상세조회
: null값 -> 빈 스트링으로 반환
- 고민생성
: dDay 값 음수로 반환
- 데드라인수정
: 에러처리 추가

## 📃 참고사항
<!-- 참고한 사항이나 참고해야할 사항이 있다면 작성해주세요. -->
