### PR TITLE
[FIX] refreshToken unique restraint 제거

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,7 +67,7 @@ model worry {
 
 model token {
   user_id       Int     @id
-  refresh_token String? @unique @db.VarChar(150)
+  refresh_token String? @db.VarChar(150)
   device_token  String?
   user          user    @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "token_user_id_fk")
 }

--- a/src/repository/tokenRepository.ts
+++ b/src/repository/tokenRepository.ts
@@ -32,16 +32,6 @@ const findDeviceTokenById = async (userId: number) => {
     });
 };
 
-const findIdByRefreshToken = async (refreshToken: string) => {
-    return await prisma.token.findUnique({
-        select:{
-            user_id:true
-        },
-        where: {
-            refresh_token: refreshToken
-        }
-    });
-};
 
 const findDeviceTokenListByIds = async (userId: number[]) => {
     return await prisma.token.findMany({
@@ -105,7 +95,6 @@ export default {
     createRefreshToken,
     findRefreshTokenById,
     findDeviceTokenById,
-    findIdByRefreshToken,
     findDeviceTokenListByIds,
     updateTokenById,
     disableRefreshTokenById,

--- a/src/service/tokenService.ts
+++ b/src/service/tokenService.ts
@@ -2,14 +2,18 @@ import { ClientException } from "../common/error/exceptions/customExceptions";
 import jwtHandler from "../modules/jwtHandler";
 import tokenRepository from "../repository/tokenRepository";
 
-const refreshAccessToken =async (refreshToken:string) => {
-   
-    const user = await tokenRepository.findIdByRefreshToken(refreshToken)
-    if(!user){
-        throw new ClientException("refresh token not found in database");
-    }
+const refreshAccessToken =async (userId: number, refreshToken:string) => {
 
-    const token = jwtHandler.access(user.user_id);
+    const user = await tokenRepository.findRefreshTokenById(userId)
+    if(!user){
+        throw new ClientException("Invlalid userId | accessToken");
+    }
+    if(user.refresh_token != refreshToken){
+        throw new ClientException("Invalid refreshToken(refreshToken doesn't match with user)");
+    }
+    console.log("here: ", user.refresh_token)
+
+    const token = jwtHandler.access(userId);
     const data = {
         "accessToken": token
     }


### PR DESCRIPTION
## 🔎 관련이슈
<!-- closed #이슈번호 -->

## ✨ 변경사항
token 테이블의 refresh_token 컬럼 unique restraint 제거
`로그아웃시, refresh_token 값이 모두 "" 로 바뀌기 때문에 unique할 수가 없음.`

이로 인해, `토큰 재발급 API`사용시 호출되는 getIdByRefreshToken 함수도 무의미해짐.
refresh token이 unique할 경우엔 해당 값을 가지고 특정 유저 id를 식별할 수 있었으나,
현 상황에서는 불가해짐.
때문에 유저 id를 해당 API 사용시 body값으로 넘겨주는 **만료된 accessToken**을 **decode**하여 얻어오는 것으로 수정


## 📃 참고사항
<!-- 참고한 사항이나 참고해야할 사항이 있다면 작성해주세요. -->
만료된 accessToken에서 payload를 가져와야 하는 상황이므로 jwt.verify 함수가 아닌, `jwt.decode` 함수를 사용한다.
`jwt.verify` 함수의 경우 accessToken 의 verification이 이루어지므로, 만료된 accessToken 의 경우 에러 메시지를 리턴하기 때문.